### PR TITLE
Support for heredoc style info in ini files, as subclass, with some requisite changes to parents

### DIFF
--- a/examples/here-doc.ini
+++ b/examples/here-doc.ini
@@ -1,0 +1,16 @@
+root=something
+
+[section]
+zero=<<EOH
+EOH
+one=<<EOH
+one is a fine number, it is always first in line!
+EOH
+two=<<EOTwo
+two is also a fine
+with more than one line!
+EOTwo
+whitespace = << EOW
+test some whitespace around the heredoc terminator.
+EOW
+blank=

--- a/lib/Config/INI/Reader.pm
+++ b/lib/Config/INI/Reader.pm
@@ -111,7 +111,7 @@ sub read_handle {
 
     if (my ($name, $value) = $self->parse_value_assignment($line)) {
       $self->set_value($name, $value);
-      next;
+      next LINE;
     }
 
     $self->handle_unparsed_line($handle, $line);

--- a/lib/Config/INI/Reader.pm
+++ b/lib/Config/INI/Reader.pm
@@ -94,8 +94,11 @@ sub read_handle {
 
   my $self = ref $invocant ? $invocant : $invocant->new;
 
+  # easy access to handle for subclasses
+  $self->{handle} = $handle;
+
   # parse the file
-  LINE: while (my $line = $handle->getline) {
+  LINE: while (my $line = $self->{handle}->getline) {
     next LINE if $self->can_ignore($line);
 
     $self->preprocess_line(\$line);
@@ -109,12 +112,12 @@ sub read_handle {
       next LINE;
     }
 
-    if (my ($name, $value) = $self->parse_value_assignment($line, $handle)) {
+    if (my ($name, $value) = $self->parse_value_assignment($line)) {
       $self->set_value($name, $value);
       next LINE;
     }
 
-    $self->handle_unparsed_line($handle, $line);
+    $self->handle_unparsed_line($line);
   }
 
   $self->finalize;
@@ -178,7 +181,7 @@ sub change_section {
 
 =head2 parse_value_assignment
 
-  my ($name, $value) = $reader->parse_value_assignment($line, $handle);
+  my ($name, $value) = $reader->parse_value_assignment($line);
 
 Given a line of input, this method decides whether the line is a property
 value assignment.  If it is, it returns the name of the property and the value
@@ -260,8 +263,8 @@ anything it recognizes.  By default, it throws an exception.
 =cut
 
 sub handle_unparsed_line {
-  my ($self, $handle, $line) = @_;
-  my $lineno = $handle->input_line_number;
+  my ($self, $line) = @_;
+  my $lineno = $self->{handle}->input_line_number;
   Carp::croak "Syntax error at line $lineno: '$line'";
 }
 

--- a/lib/Config/INI/Reader.pm
+++ b/lib/Config/INI/Reader.pm
@@ -109,7 +109,7 @@ sub read_handle {
       next LINE;
     }
 
-    if (my ($name, $value) = $self->parse_value_assignment($line)) {
+    if (my ($name, $value) = $self->parse_value_assignment($line, $handle)) {
       $self->set_value($name, $value);
       next LINE;
     }
@@ -178,7 +178,7 @@ sub change_section {
 
 =head2 parse_value_assignment
 
-  my ($name, $value) = $reader->parse_value_assignment($line);
+  my ($name, $value) = $reader->parse_value_assignment($line, $handle);
 
 Given a line of input, this method decides whether the line is a property
 value assignment.  If it is, it returns the name of the property and the value

--- a/lib/Config/INI/Reader/HereDoc.pm
+++ b/lib/Config/INI/Reader/HereDoc.pm
@@ -1,0 +1,142 @@
+use strict;
+use warnings;
+package Config::INI::Reader::HereDoc;
+# ABSTRACT: subclassed .ini-file parser, with here-doc support
+
+use parent qw(Config::INI::Reader);
+
+=head1 SYNOPSIS
+
+If F<family.ini> contains:
+
+  admin = rosey
+
+  [judy]
+  awesome = yes
+  height = 5' 7"
+
+  [astro]
+  awesome = totally
+  height = 23"
+
+  [george]
+  awesome = << EOH
+  Totally!
+  He had a flying car!
+  EOH
+  height = 5' 10"
+
+Then when your program contains:
+
+  my $hash = Config::INI::Reader::HereDoc->read_file('family.ini');
+
+C<$hash> will contain:
+
+  {
+    '_'  => { admin => 'rosey' },
+    judy => {
+      awesome => 'yes',
+      height  => q{5' 7"},
+    },
+    astro   => {
+      awesome => 'totally',
+      height  => '23"',
+    },
+    george   => {
+      awesome => "Totally!\nHe had a flying car!",
+      height  => '5' 10"',
+    },
+  }
+
+=head1 DESCRIPTION
+
+Config::INI::Reader::HereDoc is a simple subclass of L<Config::INI::Reader>.
+It extends the basic reader by adding support for here-doc style value
+assignments.
+
+=cut
+
+=head1 SUBCLASSED METHODS
+
+These methods extend behavior from L<Config::INI::Reader>.
+
+=head2 parse_value_assignment
+
+  my ($name, $value) = $reader->parse_value_assignment($line, $handle);
+
+Given a line of input, this method decides whether the line is a property
+value assignment.  If it is, it returns the name of the property and the value
+being assigned to it.  If the line is not a property assignment, the method
+returns false.
+
+=cut
+
+sub parse_value_assignment {
+  my($self, $line, $handle) = @_;
+  my($name, $value);
+
+  ($name, $value) =
+      $self->parse_heredoc_assignment($line, $handle);
+  return ($name, $value) if $name;
+  ($name, $value) =
+      $self->SUPER::parse_value_assignment($line, $handle);
+  return ($name, $value) if $name;
+  return;
+}
+
+=head1 METHODS
+
+=head2 parse_heredoc_assignment
+
+  my ($name, $value) = $reader->parse_heredoc_assignment($line, $handle);
+
+Given a line of input, this method decides whether the line is a
+heredoc style property value assignment.  If it is, it returns the
+name of the property and the value being assigned to it.  If the line
+is not a property assignment, the method returns false.
+
+This method will die with a useful error message if it runs out of
+input without finding the heredoc terminator.
+
+=cut
+
+sub parse_heredoc_assignment {
+  my ($self, $line, $handle) = @_;
+  my $heredoc_starting_line_number = $handle->input_line_number;
+
+  return unless $line =~ /^\s*([^=\s][^=]*?)\s*=\s*<<\s*([^\s]*?)\s*$/;
+  my ($name, $terminator) = ($1, $2);
+
+  my $value = '';
+  my $saw_terminator;
+ HEREDOC:
+  while (my $line = $handle->getline) {
+    last HEREDOC
+      if ($saw_terminator = $self->match_heredoc_terminator($line, $terminator));
+    $value .= $line;
+  }
+  chomp($value);
+
+  die "Ran out of input without finding heredoc terminator (\"$terminator\")," .
+    " heredoc began at line $heredoc_starting_line_number"
+    unless $saw_terminator;
+
+  return ($name, $value);
+}
+
+=head2 match_heredoc_terminator
+
+  my $matched = $reader->match_heredoc_terminator($line, $terminator);
+
+Given a line of input and a terminator string, this method decides
+whether the line matches the terminator.  It returns true if the line
+matches the terminator, false otherwise.
+
+=cut
+
+sub match_heredoc_terminator {
+  return $_[1] =~ /$_[2]$/;
+}
+
+
+1;

--- a/lib/Config/INI/Reader/HereDoc.pm
+++ b/lib/Config/INI/Reader/HereDoc.pm
@@ -72,14 +72,14 @@ returns false.
 =cut
 
 sub parse_value_assignment {
-  my($self, $line, $handle) = @_;
+  my($self, $line) = @_;
   my($name, $value);
 
   ($name, $value) =
-      $self->parse_heredoc_assignment($line, $handle);
+      $self->parse_heredoc_assignment($line);
   return ($name, $value) if $name;
   ($name, $value) =
-      $self->SUPER::parse_value_assignment($line, $handle);
+      $self->SUPER::parse_value_assignment($line);
   return ($name, $value) if $name;
   return;
 }
@@ -101,7 +101,8 @@ input without finding the heredoc terminator.
 =cut
 
 sub parse_heredoc_assignment {
-  my ($self, $line, $handle) = @_;
+  my ($self, $line) = @_;
+  my $handle = $self->{handle};
   my $heredoc_starting_line_number = $handle->input_line_number;
 
   return unless $line =~ /^\s*([^=\s][^=]*?)\s*=\s*<<\s*([^\s]*?)\s*$/;

--- a/lib/Config/INI/Writer.pm
+++ b/lib/Config/INI/Writer.pm
@@ -195,32 +195,41 @@ sub preprocess_input {
   return \@new_data;
 }
 
-=head2 invalid_section_name_regexp
+=head2 validate_section_name
 
   Carp::croak "section name contains illegal character"
-    if $name =~ $writer->invalid_section_name_regexp();
+    if not $writer->is_valid_section_name($name);
 
 =cut
 
-sub invalid_section_name_regexp { qr/(?:\n|\s;|^\s|\s$)/ }
+sub is_valid_section_name {
+    my ($self, $name) = @_;
+    return $name !~ qr/(?:\n|\s;|^\s|\s$)/;
+}
 
-=head2 invalid_property_name_regexp
+=head2 is_valid_property_name
 
   Carp::croak "property name contains illegal character"
-    if $name =~ $writer->invalid_property_name_regexp();
+    if not $writer->is_valid_property_name($name);
 
 =cut
 
-sub invalid_property_name_regexp { qr/(?:\n|\s;|^\s|\s|=$)/ }
+sub is_valid_property_name {
+    my ($self, $property) = @_;
+    return $property !~ qr/(?:\n|\s;|^\s|\s|=$)/;
+}
 
-=head2 invalid_value_regexp
+=head2 is_valid_value
 
   Carp::croak "value contains illegal character"
-    if $value =~ $writer->invalid_value_regexp();
+    if not $writer->is_valid_value($name);
 
 =cut
 
-sub invalid_value_regexp { qr/(?:\n|\s;|^\s|\s$)/ }
+sub is_valid_value {
+    my ($self, $value) = @_;
+    return $value !~ qr/(?:\n|\s;|^\s|\s$)/;
+}
 
 =head2 validate_input
 
@@ -246,17 +255,17 @@ sub validate_input {
     $seen{ $name } ||= {};
 
     Carp::croak "illegal section name '$name'"
-      if $name =~ $self->invalid_section_name_regexp;
+      if not $self->is_valid_section_name($name);
 
     for (my $j = 0; $j < $#$props; $j += 2) {
       my $property = $props->[ $j ];
       my $value    = $props->[ $j + 1 ];
 
       Carp::croak "property name '$property' contains illegal character"
-        if $property =~ $self->invalid_property_name_regexp;
+        if not $self->is_valid_property_name($property);
 
       Carp::croak "value for $name.$property contains illegal character"
-        if defined $value and $value =~ $self->invalid_value_regexp;
+        if defined $value and not $self->is_valid_value($value);
 
       if ( $seen{ $name }{ $property }++ ) {
         Carp::croak "multiple assignments found for $name.$property";

--- a/lib/Config/INI/Writer.pm
+++ b/lib/Config/INI/Writer.pm
@@ -195,6 +195,33 @@ sub preprocess_input {
   return \@new_data;
 }
 
+=head2 invalid_section_name_regexp
+
+  Carp::croak "section name contains illegal character"
+    if $name =~ $writer->invalid_section_name_regexp();
+
+=cut
+
+sub invalid_section_name_regexp { qr/(?:\n|\s;|^\s|\s$)/ }
+
+=head2 invalid_property_name_regexp
+
+  Carp::croak "property name contains illegal character"
+    if $name =~ $writer->invalid_property_name_regexp();
+
+=cut
+
+sub invalid_property_name_regexp { qr/(?:\n|\s;|^\s|\s|=$)/ }
+
+=head2 invalid_value_regexp
+
+  Carp::croak "value contains illegal character"
+    if $value =~ $writer->invalid_value_regexp();
+
+=cut
+
+sub invalid_value_regexp { qr/(?:\n|\s;|^\s|\s$)/ }
+
 =head2 validate_input
 
   $writer->validate_input($input);
@@ -219,17 +246,17 @@ sub validate_input {
     $seen{ $name } ||= {};
 
     Carp::croak "illegal section name '$name'"
-      if $name =~ /(?:\n|\s;|^\s|\s$)/;
+      if $name =~ $self->invalid_section_name_regexp;
 
     for (my $j = 0; $j < $#$props; $j += 2) {
       my $property = $props->[ $j ];
       my $value    = $props->[ $j + 1 ];
 
       Carp::croak "property name '$property' contains illegal character"
-        if $property =~ /(?:\n|\s;|^\s|\s|=$)/;
+        if $property =~ $self->invalid_property_name_regexp;
 
       Carp::croak "value for $name.$property contains illegal character"
-        if defined $value and $value =~ /(?:\n|\s;|^\s|\s$)/;
+        if defined $value and $value =~ $self->invalid_value_regexp;
 
       if ( $seen{ $name }{ $property }++ ) {
         Carp::croak "multiple assignments found for $name.$property";

--- a/lib/Config/INI/Writer/HereDoc.pm
+++ b/lib/Config/INI/Writer/HereDoc.pm
@@ -1,0 +1,123 @@
+use strict;
+use warnings;
+package Config::INI::Writer::HereDoc;
+# ABSTRACT: a Config::INI::Writer subclass that handles heredoc-style values.
+
+use parent qw(Config::INI::Writer);
+
+=head1 SYNOPSIS
+
+If <$hash> contains:
+
+  {
+    '_'  => { admin => 'rosey' },
+    judy => {
+      awesome => 'yes',
+      height  => q{5' 7"},
+    },
+    astro   => {
+      awesome => 'totally',
+      height  => '23"',
+    },
+    george   => {
+      awesome => "Totally!\nHe had a flying car!",
+      height  => '5' 10"',
+    },
+  }
+
+Then when your program contains:
+
+  Config::INI::Writer::HereDoc->write_file($hash, 'family.ini');
+
+F<family.ini> will contains:
+
+  admin = rosey
+
+  [judy]
+  awesome = yes
+  height = 5' 7"
+
+  [astro]
+  awesome = totally
+  height = 23"
+
+  [george]
+  awesome = << EOH
+  Totally!
+  He had a flying car!
+  EOH
+  height = 5' 10"
+
+=head1 DESCRIPTION
+
+Config::INI::Writer::HereDoc is a subclass of L<Config::INI::Writer> that
+handles values with embedded newlines by writing them out in heredoc format.
+
+=head1 SUBCLASSED METHODS
+
+These methods extend behavior from L<Config::INI::Writer>.
+
+=head2 invalid_value_regexp
+
+  Carp::croak "value contains illegal character"
+    if $value =~ $writer->invalid_value_regexp();
+
+=cut
+
+sub invalid_value_regexp { qr/(?:\s;|^\s|\s$)/ }
+
+=head2 stringify_value_assignment
+
+  my $string = $writer->stringify_value_assignment($name => $value);
+
+This method returns a string that assigns a value to a named property.  If the
+value is undefined, an empty string is returned.
+
+=cut
+
+sub stringify_value_assignment {
+  my ($self, $name, $value) = @_;
+
+  return '' unless defined $value;
+
+  return $name . ' = ' . $self->stringify_value_as_heredoc($value) . "\n"
+    unless (index($value, "\n") < 0);
+  
+  return $self->SUPER::stringify_value_assignment($name, $value);
+}
+
+=head1 METHODS
+
+=head2 next_heredoc_terminator
+
+  my $terminator = $writer->next_heredoc_terminator();
+
+This method returns a unique string that can be used to terminate a
+heredoc.
+
+=cut
+
+our $_heredoc_id = 0;
+sub next_heredoc_terminator {
+  return "EOH_" . $_heredoc_id++;
+}
+
+=head2 stringify_value_as_heredoc
+
+  my $string = $writer->stringify_value_as_heredoc($value);
+
+This method returns the string, in heredoc format, that will represent
+the given value in a property assignment.
+
+It uses the L<next_heredoc_terminator> method to generate a unique
+heredoc terminator.
+
+=cut
+
+sub stringify_value_as_heredoc {
+  my ($self, $value) = @_;
+  my $terminator = $self->next_heredoc_terminator;
+  return "<< $terminator\n$value\n$terminator";
+}
+
+1;

--- a/lib/Config/INI/Writer/HereDoc.pm
+++ b/lib/Config/INI/Writer/HereDoc.pm
@@ -57,14 +57,17 @@ handles values with embedded newlines by writing them out in heredoc format.
 
 These methods extend behavior from L<Config::INI::Writer>.
 
-=head2 invalid_value_regexp
+=head2 is_valid_value
 
   Carp::croak "value contains illegal character"
-    if $value =~ $writer->invalid_value_regexp();
+    unless $writer->is_valid_value($value);
 
 =cut
 
-sub invalid_value_regexp { qr/(?:\s;|^\s|\s$)/ }
+sub is_valid_value {
+    my ($self, $value) = @_;
+    return $value !~ qr/(?:\s;|^\s|\s$)/
+}
 
 =head2 stringify_value_assignment
 

--- a/t/reader-here-doc.t
+++ b/t/reader-here-doc.t
@@ -39,7 +39,7 @@ now is the time
 for something or other
 END
   my $hashref;
-  eval { $hashref = Config::INI::Reader->read_string( $fubar_string ); };
+  eval { $hashref = Config::INI::Reader::HereDoc->read_string( $fubar_string ); };
   like($@, qr/Ran out of input.*\("EOH"\)/,
        "Heredoc without a terminator dies as expected");
 }

--- a/t/reader-here-doc.t
+++ b/t/reader-here-doc.t
@@ -1,0 +1,45 @@
+#!perl -Tw
+
+use strict;
+
+use IO::File;
+use IO::String;
+use Test::More tests => 4;
+
+# Check their perl version
+use_ok('Config::INI::Reader::HereDoc');
+
+# Make sure that here docs work
+my $here_hashref =
+   Config::INI::Reader::HereDoc->read_file( 'examples/here-doc.ini' );
+isa_ok($here_hashref, 'HASH', "return Config...->read_file(here-doc.ini)");
+
+# Check the structure of the config
+my $here_expected = {
+  '_' => {
+    root => 'something',
+  },
+  section => {
+    zero  => "",
+    one   => "one is a fine number, it is always first in line!",
+    two   => "two is also a fine\nwith more than one line!",
+    whitespace  => "test some whitespace around the heredoc terminator.",
+    blank => '',
+  },
+};
+
+is_deeply($here_hashref, $here_expected,
+          'Config structure w/ heredoc matches expected');
+
+{
+  my $fubar_string = <<END;
+a = b
+c = <<EOH
+now is the time
+for something or other
+END
+  my $hashref;
+  eval { $hashref = Config::INI::Reader->read_string( $fubar_string ); };
+  like($@, qr/Ran out of input.*\("EOH"\)/,
+       "Heredoc without a terminator dies as expected");
+}

--- a/t/reader.t
+++ b/t/reader.t
@@ -33,7 +33,7 @@ my $expected = {
 
 is_deeply($hashref, $expected, 'Config structure matches expected');
 
-# Add some stuff to the trivial config and check write_string() for it
+# Add some stuff to the trivial config and check read_string() for it
 my $Trivial = {};
 $Trivial->{_} = { root1 => 'root2' };
 $Trivial->{section} = {

--- a/t/writer-heredoc.t
+++ b/t/writer-heredoc.t
@@ -1,0 +1,72 @@
+#!perl -Tw
+
+use strict;
+
+use Test::More tests => 6;
+
+my $R = 'Config::INI::Reader::HereDoc';
+my $W = 'Config::INI::Writer::HereDoc';
+
+use_ok($_) for $R, $W;
+
+my $data = {
+  _ => {
+    a => 1,
+    b => 2,
+    c => 3,
+  },
+  foo => {
+    bar  => 'baz',
+    baz  => "bar\nbar",
+  },
+};
+
+is_deeply(
+  $R->read_string($W->write_string($data)),
+  $data,
+  'we can round-trip hashy data',
+);
+
+is_deeply(
+  $R->read_string($W->new->write_string($data)),
+  $data,
+  'we can round-trip hashy data, object method',
+);
+
+my $starting_first = [
+  _ => [
+    a => 1,
+    b => 2,
+    c => 3,
+   ],
+  foo => [
+    bar  => 'baz',
+    baz  => "bar\nbar",
+    quux => undef,
+  ],
+];
+
+my $expected = qr/a = 1
+b = 2
+c = 3
+
+\[foo\]
+bar = baz
+baz = << EOH_[\d]
+bar
+bar
+EOH_[\d]
+/;
+
+like(
+  $W->write_string($starting_first),
+  $expected,
+  'stringifying AOA, _ first',
+);
+
+like(
+  $W->new->write_string($starting_first),
+  $expected,
+  'stringifying AOA, _ first, object method',
+);
+


### PR DESCRIPTION
Hi Ricardo,

Here's a stab at doing this as via subclasses, with minimal changes to the parent classes to improve their subclassability.  Assuming I'm github-ing correctly you should see a series of commits:
1. a pair of commits that fixes a comment in a test file and that adds a label to a `next` statement so that it matches it surroundings better.
2. a commit that adds a test file and some sample data for reading heredoc style ini files
3. a commit that improves the subclass-ability of Config::INI::Reader
4. oops, touch up the reader test
5. Config::INI::Reader::HereDoc
6. a commit that improves the subclass-ability of Config::INI::Writer
7. a test for a heredoc-enabled writer
8. Config::INI::Writer::HereDoc

I suppose I could break Config;:INI::{Reader,Writer}::HereDoc out into their own distributions, but they're awfully minimal....

Feedback?

Thanks!
g.
