### PR TITLE
Specify min Mixin::Linewise requirement

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Changelog for Config-INI
 
 {{$NEXT}}
+        - specify minimum Mixin::Linewise requirement (thanks, Andreas Koenig
+          and Smylers)
 
 0.022     2014-01-30 16:57:43-05:00 America/New_York
         - remove the last few places IO::String was used (thanks, Graham Knop)

--- a/lib/Config/INI/Reader.pm
+++ b/lib/Config/INI/Reader.pm
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 package Config::INI::Reader;
 
-use Mixin::Linewise::Readers;
+use Mixin::Linewise::Readers 0.100;
 # ABSTRACT: a subclassable .ini-file parser
 
 =head1 SYNOPSIS


### PR DESCRIPTION
Needed for t/reader-err.t to pass.

The bom check added in 1ec26331 is for UTF-8 input, and since 226272d1
t/reader-err.t checks for this. But that test only passes if the input
actually is UTF-8. Mixin::Linewise changed to defaulting to UTF-8 in
0.100.

With older versions of Mixin::Linewise, the input stream wasn't UTF-8, so
the first character read wasn't a bom, but just the byte EF. So no ‘no
bom’ error was thrown, and the test failed.

Issue #7
